### PR TITLE
Add Spring Boot Todo Application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.codemie</groupId>
+    <artifactId>todoapp</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Todo Application</name>
+    <description>Spring Boot Todo Application</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.5.4</version>
+        <relativePath />
+    </parent>
+
+    <properties>
+        <java.version>11</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/codemie/todoapp/TodoApplication.java
+++ b/src/main/java/com/codemie/todoapp/TodoApplication.java
@@ -1,0 +1,13 @@
+package com.codemie.todoapp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TodoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TodoApplication.class, args);
+    }
+
+}

--- a/src/main/java/com/codemie/todoapp/controller/TodoController.java
+++ b/src/main/java/com/codemie/todoapp/controller/TodoController.java
@@ -1,0 +1,35 @@
+package com.codemie.todoapp.controller;
+
+import com.codemie.todoapp.model.Todo;
+import com.codemie.todoapp.repository.TodoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+public class TodoController {
+
+    @Autowired
+    private TodoRepository todoRepository;
+
+    @GetMapping("/")
+    public String index(Model model) {
+        model.addAttribute("todos", todoRepository.findAll());
+        model.addAttribute("todo", new Todo());
+        return "index";
+    }
+
+    @PostMapping("/addTodo")
+    public String addTodo(@ModelAttribute Todo todo) {
+        todoRepository.save(todo);
+        return "redirect:/";
+    }
+
+    @GetMapping("/deleteTodo/{id}")
+    public String deleteTodo(@PathVariable Long id) {
+        todoRepository.deleteById(id);
+        return "redirect:/";
+    }
+
+}

--- a/src/main/java/com/codemie/todoapp/model/Todo.java
+++ b/src/main/java/com/codemie/todoapp/model/Todo.java
@@ -1,0 +1,41 @@
+package com.codemie.todoapp.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Todo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private String title;
+    private String description;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/codemie/todoapp/repository/TodoRepository.java
+++ b/src/main/java/com/codemie/todoapp/repository/TodoRepository.java
@@ -1,0 +1,7 @@
+package com.codemie.todoapp.repository;
+
+import com.codemie.todoapp.model.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=password
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Todo App</title>
+</head>
+<body>
+<h1>Todo List</h1>
+<form th:action="@{/addTodo}" th:object="${todo}" method="post">
+    <input type="text" th:field="*{title}" placeholder="Title" required/>
+    <input type="text" th:field="*{description}" placeholder="Description"/>
+    <button type="submit">Add</button>
+</form>
+<table>
+    <tr>
+        <th>Title</th>
+        <th>Description</th>
+        <th>Action</th>
+    </tr>
+    <th:block th:each="todo : ${todos}">
+        <tr>
+            <td th:text="${todo.title}">Title</td>
+            <td th:text="${todo.description}">Description</td>
+            <td><a th:href="@{/deleteTodo/{id}(id=${todo.id})}">Delete</a></td>
+        </tr>
+    </th:block>
+</table>
+</body>
+</html>

--- a/src/test/java/com/codemie/todoapp/TodoApplicationTests.java
+++ b/src/test/java/com/codemie/todoapp/TodoApplicationTests.java
@@ -1,0 +1,12 @@
+package com.codemie.todoapp;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TodoApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
This PR adds a complete Spring Boot Todo application with the following features:

1. Create and display todo items
2. Delete todo items
3. Uses Spring Boot, Spring Data JPA, Thymeleaf, and H2 database.

### Changes:
- Add main application class `TodoApplication.java`
- Add controller `TodoController.java`
- Add model `Todo.java`
- Add repository interface `TodoRepository.java`
- Add Thymeleaf template for UI `index.html`
- Add application properties `application.properties`
- Add tests `TodoApplicationTests.java`
- Add dependencies and build configuration in `pom.xml`.

Please review and merge.