### PR TITLE
Fix code smell issue in GlobalExceptionHandler.java

### DIFF
--- a/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
@@ -17,7 +17,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
-        ex.getBindingResult().getAllErrors().forEach((error) -> {
+        ex.getBindingResult().getAllErrors().forEach(error -> {
             String fieldName = ((FieldError) error).getField();
             String errorMessage = error.getDefaultMessage();
             errors.put(fieldName, errorMessage);


### PR DESCRIPTION
This PR fixes the code smell issue mentioned in JIRA ticket EPMCDMETST-5760 by removing unnecessary parentheses around the 'error' parameter in the lambda expression.